### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 sudo: required
 language: python
-python: "2.7"
 
 env:
   - SITE=test1.yml
@@ -12,7 +11,7 @@ before_install:
 
 install:
   # Install Ansible.
-  - pip install ome-ansible-molecule-dependencies
+  - pip install ome-ansible-molecule
 
   # Add ansible.cfg to pick up roles path.
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"

--- a/templates/plugin-conf.j2
+++ b/templates/plugin-conf.j2
@@ -1,6 +1,6 @@
-{% for section,directives in munin_node_config.iteritems() %}
+{% for section,directives in munin_node_config.items() %}
 [{{section}}]
-{% for name,val in directives.iteritems() %}
+{% for name,val in directives.items() %}
 {{ name }} {{ val }}
 {% endfor %}
 


### PR DESCRIPTION
Discovered while testing https://github.com/IDR/deployment/pull/201

This should ensure all default tasks using by the IDR deployment are compatible with a Python 3 virtual environment.

Proposed tag: `1.2.1-openmicroscopy2` for the quick fix. A separate discussion would be necessary to decide whether we want to reconcile upstream changes or complete drop `munin`